### PR TITLE
Deinstallation hinzugefügt

### DIFF
--- a/remove.ins
+++ b/remove.ins
@@ -8,7 +8,7 @@ WinBatch_Uninstall
 Sub_HandleExitCode
 
 [WinBatch_Uninstall]
-msiexec /passive /x "PATH"
+"%ScriptDrive%\tools\autoit\msiRemove_withLog.exe" "ONLYOFFICE"
 
 [Sub_HandleExitCode]
 ; check return code


### PR DESCRIPTION
Da die remove.ins noch einen Platzhalter in der `WinBatch_Uninstall` Sektion enthielt, habe ich diese mit einem Aufruf von `msiRemove_withLog.exe` zur Deinstallation von OnlyOffice ergänzt